### PR TITLE
fix build.gradle syntax for group and jar destination directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@ plugins {
     id 'java'
 }
 
-group 'emuskardin'
+group = 'emuskardin'
 
 jar {
-    destinationDir = file("$rootDir")
+    destinationDirectory = file("$rootDir")
     manifest {
         attributes 'Main-Class': 'Alergia'
     }


### PR DESCRIPTION
fix build.gradle syntax for group and jar destination directory for new gradle version support (tested with gradle 8.13)